### PR TITLE
Normative: `ToInteger`: fix spec bug from #1827 that allows (-1,0) to…

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -4831,7 +4831,9 @@
         1. Let _number_ be ? ToNumber(_argument_).
         1. If _number_ is *NaN*, *+0*, or *-0*, return *+0*.
         1. If _number_ is *+&infin;*, or *-&infin;*, return _number_.
-        1. Return the Number value that is the same sign as _number_ and whose magnitude is floor(abs(_number_)).
+        1. Let _integer_ be the Number value that is the same sign as _number_ and whose magnitude is floor(abs(_number_)).
+        1. If _integer_ is *-0*, return *+0*.
+        1. Return _integer_.
       </emu-alg>
     </emu-clause>
 


### PR DESCRIPTION
… produce `-0` (#1871)

<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://heycam.github.io/webidl/) — [file an issue](https://github.com/heycam/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
-->
