### PR TITLE
Editorial: Fix `<dfn>`s for `WeakRef` and `FinalizationRegistry` (#2318)

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -36897,7 +36897,7 @@ THH:mm:ss.sss
       <h1>The WeakRef Constructor</h1>
       <p>The <dfn>WeakRef</dfn> constructor:</p>
       <ul>
-        <li>is %WeakRef%.</li>
+        <li>is <dfn>%WeakRef%</dfn>.</li>
         <li>
           is the initial value of the *"WeakRef"* property of the global object.
         </li>
@@ -36938,14 +36938,14 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-weak-ref.prototype">
         <h1>WeakRef.prototype</h1>
-        <p>The initial value of `WeakRef.prototype` is the intrinsic %WeakRef.prototype% object.</p>
+        <p>The initial value of `WeakRef.prototype` is the WeakRef prototype object.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
     </emu-clause>
 
     <emu-clause id="sec-properties-of-the-weak-ref-prototype-object">
       <h1>Properties of the WeakRef Prototype Object</h1>
-      <p>The WeakRef prototype object:</p>
+      <p>The <dfn>WeakRef prototype</dfn> object:</p>
       <ul>
         <li>is <dfn>%WeakRef.prototype%</dfn>.</li>
         <li>
@@ -37072,14 +37072,14 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-finalization-registry.prototype">
         <h1>FinalizationRegistry.prototype</h1>
-        <p>The initial value of `FinalizationRegistry.prototype` is the intrinsic %FinalizationRegistry.prototype% object.</p>
+        <p>The initial value of `FinalizationRegistry.prototype` is the FinalizationRegistry prototype object.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
     </emu-clause>
 
     <emu-clause id="sec-properties-of-the-finalization-registry-prototype-object">
       <h1>Properties of the FinalizationRegistry Prototype Object</h1>
-      <p>The FinalizationRegistry prototype object:</p>
+      <p>The <dfn>FinalizationRegistry prototype</dfn> object:</p>
       <ul>
         <li>is <dfn>%FinalizationRegistry.prototype%</dfn>.</li>
         <li>


### PR DESCRIPTION
<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://heycam.github.io/webidl/) — [file an issue](https://github.com/heycam/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
* [ECMAScript Intl API](https://tc39.es/ecma402/) - [file an issue](https://github.com/tc39/ecma402/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->
